### PR TITLE
Fix the missing physbone colilders #11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev.kesera2.avatar-dynamics-extractor",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "displayName": "kesera2's Avatar Dynamics Extractor",
   "description": "Extract Avatar Dynamics components such as Physbone, Physbone Collider, and Contacts, then place them in the avatar root as Avatar Dynamics",
   "author": {


### PR DESCRIPTION
# Problem
- colliders of Physbone component was missing when enable the option of delte original comopnents. It was due to the fact that physbone colliders has copied and removed after physbone process.

# Changes
- The order of processing was changed from PBC to PB.
- Changed to treat already copied PBC components as colliders of Physbone.
- CopyComponent<T> returns List<T> instead of int.
- Add the function of change order of gameobjects.
